### PR TITLE
feat: add dsse verifier threshold

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,3 +1,17 @@
+# Copyright 2022 The Witness Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: golangci-lint
 on:
   push:
@@ -20,3 +34,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
+          args: --timeout=3m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,17 @@
+# Copyright 2022 The Witness Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: release
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/verify-licence.yml
+++ b/.github/workflows/verify-licence.yml
@@ -1,3 +1,17 @@
+# Copyright 2022 The Witness Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Verify License
 on:
   workflow_dispatch:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 The Witness Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_name: witness
 builds:
   - skip: true

--- a/dsse/dsse_test.go
+++ b/dsse/dsse_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dsse
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testifysec/go-witness/cryptoutil"
+)
+
+func createTestKey() (cryptoutil.Signer, cryptoutil.Verifier, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	signer := cryptoutil.NewRSASigner(privKey, crypto.SHA256)
+	verifier := cryptoutil.NewRSAVerifier(&privKey.PublicKey, crypto.SHA256)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return signer, verifier, nil
+}
+
+func TestSign(t *testing.T) {
+	signer, _, err := createTestKey()
+	require.NoError(t, err)
+	_, err = Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signer)
+	require.NoError(t, err)
+}
+
+func TestVerify(t *testing.T) {
+	signer, verifier, err := createTestKey()
+	require.NoError(t, err)
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signer)
+	require.NoError(t, err)
+	approvedVerifiers, err := env.Verify(WithVerifiers([]cryptoutil.Verifier{verifier}))
+	assert.ElementsMatch(t, approvedVerifiers, []cryptoutil.Verifier{verifier})
+	require.NoError(t, err)
+}
+
+func TestFailVerify(t *testing.T) {
+	signer, _, err := createTestKey()
+	require.NoError(t, err)
+	_, verifier, err := createTestKey()
+	require.NoError(t, err)
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signer)
+	require.NoError(t, err)
+	approvedVerifiers, err := env.Verify(WithVerifiers([]cryptoutil.Verifier{verifier}))
+	assert.Empty(t, approvedVerifiers)
+	require.ErrorIs(t, err, ErrNoMatchingSigs{})
+}
+
+func TestMultiSigners(t *testing.T) {
+	signers := []cryptoutil.Signer{}
+	verifiers := []cryptoutil.Verifier{}
+	for i := 0; i < 5; i++ {
+		s, v, err := createTestKey()
+		require.NoError(t, err)
+		signers = append(signers, s)
+		verifiers = append(verifiers, v)
+	}
+
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signers...)
+	require.NoError(t, err)
+
+	approvedVerifiers, err := env.Verify(WithVerifiers(verifiers))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, approvedVerifiers, verifiers)
+}
+
+func TestThreshold(t *testing.T) {
+	signers := []cryptoutil.Signer{}
+	expectedVerifiers := []cryptoutil.Verifier{}
+	verifiers := []cryptoutil.Verifier{}
+	for i := 0; i < 5; i++ {
+		s, v, err := createTestKey()
+		require.NoError(t, err)
+		signers = append(signers, s)
+		expectedVerifiers = append(expectedVerifiers, v)
+		verifiers = append(verifiers, v)
+	}
+
+	// create some additional verifiers that won't be used to sign
+	for i := 0; i < 5; i++ {
+		_, v, err := createTestKey()
+		require.NoError(t, err)
+		verifiers = append(verifiers, v)
+	}
+
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signers...)
+	require.NoError(t, err)
+
+	approvedVerifiers, err := env.Verify(WithVerifiers(verifiers), WithThreshold(5))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, approvedVerifiers, expectedVerifiers)
+
+	approvedVerifiers, err = env.Verify(WithVerifiers(verifiers), WithThreshold(10))
+	require.ErrorIs(t, err, ErrThresholdNotMet{Acutal: 5, Theshold: 10})
+	assert.ElementsMatch(t, approvedVerifiers, expectedVerifiers)
+
+	_, err = env.Verify(WithVerifiers(verifiers), WithThreshold(-10))
+	require.ErrorIs(t, err, ErrInvalidThreshold(-10))
+}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -67,6 +67,10 @@ func TestVerify(t *testing.T) {
 	require.NoError(t, err)
 	keyID, err := verifier.KeyID()
 	require.NoError(t, err)
+	_, verifier2, pubKeyPem2, err := createTestKey()
+	require.NoError(t, err)
+	keyID2, err := verifier2.KeyID()
+	require.NoError(t, err)
 	commandPolicy := []byte(`package test
 deny[msg] {
 	input.cmd != ["go", "build", "./"]
@@ -84,6 +88,10 @@ deny[msg] {
 			keyID: {
 				KeyID: keyID,
 				Key:   pubKeyPem,
+			},
+			keyID2: {
+				KeyID: keyID2,
+				Key:   pubKeyPem2,
 			},
 		},
 		Steps: map[string]Step{


### PR DESCRIPTION
Adds the ability to require at least a specified number of verifiers to
successfully verify a DSSE envelope.

Also fixes witness issue #194 where multiple public keys within a policy
will cause all verification to fail. This was due to the DSSE verify
function returning as soon as a single verifier fails. Now the code
appropriately tries to verify against all passed in verifiers and only
throws an error if no verifier successfully verifies the envelope or the
threshold is unmet.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>