### PR TITLE
fix: don't return error on EOF, break instead.

### DIFF
--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -178,14 +178,21 @@ func (a *Attestor) parseMaifest(ctx *attestation.AttestationContext) error {
 
 	f, err := os.Open(a.tarFilePath)
 	if err != nil {
+		err = fmt.Errorf("error opening tar file: %w", err)
 		return err
 	}
+
 	tarReader := tar.NewReader(f)
 	for {
 		h, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+
 		if err != nil {
 			return err
 		}
+
 		if h.FileInfo().IsDir() {
 			continue
 		}


### PR DESCRIPTION
I was not able to reproduce this locally for some reason but had to set up a CI job in GitLab

Here is an example of the error:
[https://gitlab.com/testifysec/judge-platform/web/-/jobs/2994900989](https://gitlab.com/testifysec/judge-platform/web/-/jobs/2994900989)

Here is an example with the fix:
[https://gitlab.com/testifysec/judge-platform/web/-/jobs/2994887589](https://gitlab.com/testifysec/judge-platform/web/-/jobs/2994887589)

This is the binary I downloaded in the pipeline
https://github.com/testifysec/witness/releases/download/v0.0.7-test-ci/witness