### PR TITLE
chore: remove fmt.Print functions in favor of log library

### DIFF
--- a/attestation/aws-iid/aws-iid.go
+++ b/attestation/aws-iid/aws-iid.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/testifysec/go-witness/attestation"
 	"github.com/testifysec/go-witness/cryptoutil"
+	"github.com/testifysec/go-witness/log"
 )
 
 const (
@@ -197,7 +198,7 @@ func (a *Attestor) Verify() error {
 
 	err = rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, docHash[:], sigBytes)
 	if err != nil {
-		fmt.Printf("failed to verify signature: %v", err)
+		log.Debugf("(attestation/aws-iid) failed to verify signature: %v", err)
 		return nil
 	}
 

--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/testifysec/go-witness/attestation"
 	"github.com/testifysec/go-witness/cryptoutil"
+	"github.com/testifysec/go-witness/log"
 )
 
 const (
@@ -90,7 +91,7 @@ func (m *Manifest) getImageID(ctx *attestation.AttestationContext, tarFilePath s
 
 			imageID, err := cryptoutil.CalculateDigestSetFromBytes(b, ctx.Hashes())
 			if err != nil {
-				fmt.Printf("error calculating image id: %s\n", err)
+				log.Debugf("(attestation/oci) error calculating image id: %v", err)
 				return nil, err
 			}
 
@@ -117,19 +118,19 @@ func (a *Attestor) RunType() attestation.RunType {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	if err := a.getCanidate(ctx); err != nil {
-		fmt.Printf("error getting canidate: %s\n", err)
+	if err := a.getCandidate(ctx); err != nil {
+		log.Debugf("(attestation/oci) error getting candidate: %v", err)
 		return err
 	}
 
 	if err := a.parseMaifest(ctx); err != nil {
-		fmt.Printf("error parsing manifest: %s\n", err)
+		log.Debugf("(attestation/oci) error parsing manifest: %v", err)
 		return err
 	}
 
 	imageID, err := a.Manifest[0].getImageID(ctx, a.tarFilePath)
 	if err != nil {
-		fmt.Printf("error getting image id: %s\n", err)
+		log.Debugf("(attestation/oci) error getting image id: %v", err)
 		return err
 	}
 
@@ -145,7 +146,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	return nil
 }
 
-func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
+func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()
 
 	if len(products) == 0 {
@@ -163,7 +164,7 @@ func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
 		}
 
 		if !newDigestSet.Equal(product.Digest) {
-			return fmt.Errorf("integrity error: product digest set does not match canidate digest set")
+			return fmt.Errorf("integrity error: product digest set does not match candidate digest set")
 		}
 
 		a.TarDigest = product.Digest

--- a/attestation/sarif/sarif.go
+++ b/attestation/sarif/sarif.go
@@ -24,6 +24,7 @@ import (
 	"github.com/owenrumney/go-sarif/sarif"
 	"github.com/testifysec/go-witness/attestation"
 	"github.com/testifysec/go-witness/cryptoutil"
+	"github.com/testifysec/go-witness/log"
 )
 
 const (
@@ -63,15 +64,15 @@ func (a *Attestor) RunType() attestation.RunType {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	if err := a.getCanidate(ctx); err != nil {
-		fmt.Printf("error getting canidate: %s\n", err)
+	if err := a.getCandidate(ctx); err != nil {
+		log.Debugf("(attestation/sarif) error getting candidate: %v", err)
 		return err
 	}
 
 	return nil
 }
 
-func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
+func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()
 
 	if len(products) == 0 {
@@ -91,7 +92,7 @@ func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
 		}
 
 		if !newDigestSet.Equal(product.Digest) {
-			return fmt.Errorf("integrity error: product digest set does not match canidate digest set")
+			return fmt.Errorf("integrity error: product digest set does not match candidate digest set")
 		}
 
 		f, err := os.Open(path)
@@ -106,7 +107,7 @@ func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
 
 		//check to see if we can unmarshal into sarif type
 		if err := json.Unmarshal(reportBytes, &a.Report); err != nil {
-			fmt.Printf("error unmarshaling report: %s\n", err)
+			log.Debugf("(attestation/sarif) error unmarshaling report: %v", err)
 			continue
 		}
 

--- a/attestation/scorecard/scorecard.go
+++ b/attestation/scorecard/scorecard.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/testifysec/go-witness/attestation"
 	"github.com/testifysec/go-witness/cryptoutil"
+	"github.com/testifysec/go-witness/log"
 )
 
 const (
@@ -64,18 +65,17 @@ func (a *Attestor) RunType() attestation.RunType {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-
 	a.hashes = ctx.Hashes()
 
-	if err := a.getCanidate(ctx); err != nil {
-		fmt.Printf("error getting canidate: %s\n", err)
+	if err := a.getCandidate(ctx); err != nil {
+		log.Debug("(attestation/scorecard) error getting candidate: %v", err)
 		return err
 	}
 
 	return nil
 }
 
-func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
+func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()
 
 	if len(products) == 0 {
@@ -95,7 +95,7 @@ func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
 		}
 
 		if !newDigestSet.Equal(product.Digest) {
-			return fmt.Errorf("integrity error: product digest set does not match canidate digest set")
+			return fmt.Errorf("integrity error: product digest set does not match candidate digest set")
 		}
 
 		f, err := os.Open(path)
@@ -110,7 +110,7 @@ func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
 
 		//check to see if we can unmarshal into scorecard type
 		if err := json.Unmarshal(reportBytes, &a.Scorecard); err != nil {
-			fmt.Printf("error unmarshaling report: %s\n", err)
+			log.Debug("(attestation/scorecard) error unmarshaling report: %v", err)
 			continue
 		}
 

--- a/rekor/rekor.go
+++ b/rekor/rekor.go
@@ -84,7 +84,7 @@ func (r *wrappedRekorClient) StoreArtifact(artifactBytes, pubkeyBytes []byte) (*
 	})
 
 	if err != nil {
-		fmt.Println("error creating entry:", err)
+		log.Debugf("(rekor) error creating entry: %v", err)
 		return nil, err
 	}
 

--- a/rekor/rekor_test.go
+++ b/rekor/rekor_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -126,7 +125,7 @@ func Test_wrappedRekorClient_StoreArtifact(t *testing.T) {
 	require.NoError(t, err)
 
 	signedBytes, err := json.MarshalIndent(result.SignedEnvelope, "", "  ")
-	fmt.Println(string(signedBytes))
+	t.Logf("signed bytes: %v\b", string(signedBytes))
 	require.NoError(t, err)
 
 	require.NoError(t, err)
@@ -175,7 +174,7 @@ func Test_FindEvidence(t *testing.T) {
 
 	entry, err := rc.FindEvidence([]cryptoutil.DigestSet{ds}, policyEnvelope, []cryptoutil.Verifier{verifier}, []witness.CollectionEnvelope{}, 2)
 	for _, e := range entry {
-		fmt.Println(e.Reference)
+		t.Logf("reference: %v\n", e.Reference)
 	}
 
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Mikhail Swift <mikhail@testifysec.com>