### PR TITLE
RFC 3161 Timestamping Support

### DIFF
--- a/cryptoutil/util.go
+++ b/cryptoutil/util.go
@@ -133,3 +133,17 @@ func TryParseKeyFromReader(r io.Reader) (interface{}, error) {
 	pemBlock, _ := pem.Decode(bytes)
 	return TryParsePEMBlock(pemBlock)
 }
+
+func TryParseCertificate(data []byte) (*x509.Certificate, error) {
+	possibleCert, err := TryParseKeyFromReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	cert, ok := possibleCert.(*x509.Certificate)
+	if !ok {
+		return nil, fmt.Errorf("data was a valid verifier but not a certificate")
+	}
+
+	return cert, nil
+}

--- a/dsse/dsse.go
+++ b/dsse/dsse.go
@@ -15,14 +15,7 @@
 package dsse
 
 import (
-	"bytes"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"io"
-	"time"
-
-	"github.com/testifysec/go-witness/cryptoutil"
 )
 
 type ErrNoSignatures struct{}
@@ -61,12 +54,20 @@ type Envelope struct {
 }
 
 type Signature struct {
-	KeyID         string   `json:"keyid"`
-	Signature     []byte   `json:"sig"`
-	Certificate   []byte   `json:"certificate,omitempty"`
-	Intermediates [][]byte `json:"intermediates,omitempty"`
+	KeyID         string               `json:"keyid"`
+	Signature     []byte               `json:"sig"`
+	Certificate   []byte               `json:"certificate,omitempty"`
+	Intermediates [][]byte             `json:"intermediates,omitempty"`
+	Timestamps    []SignatureTimestamp `json:"timestamps,omitempty"`
+}
 
-	trustedTime time.Time
+type SignatureTimestampType string
+
+const TimestampRFC3161 SignatureTimestampType = "tsp"
+
+type SignatureTimestamp struct {
+	Type SignatureTimestampType `json:"type"`
+	Data []byte                 `json:"data"`
 }
 
 // preauthEncode wraps the data to be signed or verified and it's type in the DSSE protocol's
@@ -75,206 +76,4 @@ type Signature struct {
 func preauthEncode(bodyType string, body []byte) []byte {
 	const dsseVersion = "DSSEv1"
 	return []byte(fmt.Sprintf("%s %d %s %d %s", dsseVersion, len(bodyType), bodyType, len(body), body))
-}
-
-// TODO: it'd be nice to break some of this logic out of what should be a presentation layer only
-func Sign(bodyType string, body io.Reader, signers ...cryptoutil.Signer) (Envelope, error) {
-	env := Envelope{}
-	bodyBytes, err := io.ReadAll(body)
-	if err != nil {
-		return env, err
-	}
-
-	env.PayloadType = bodyType
-	env.Payload = bodyBytes
-	env.Signatures = make([]Signature, 0)
-	pae := preauthEncode(bodyType, bodyBytes)
-	for _, signer := range signers {
-		sig, err := signer.Sign(bytes.NewReader(pae))
-		if err != nil {
-			return env, err
-		}
-
-		keyID, err := signer.KeyID()
-		if err != nil {
-			return env, err
-		}
-
-		dsseSig := Signature{
-			KeyID:     keyID,
-			Signature: sig,
-		}
-
-		if trustBundler, ok := signer.(cryptoutil.TrustBundler); ok {
-			leaf := trustBundler.Certificate()
-			intermediates := trustBundler.Intermediates()
-			if leaf != nil {
-				dsseSig.Certificate = pem.EncodeToMemory(&pem.Block{Type: PemTypeCertificate, Bytes: leaf.Raw})
-			}
-
-			for _, intermediate := range intermediates {
-				dsseSig.Intermediates = append(dsseSig.Intermediates, pem.EncodeToMemory(&pem.Block{Type: PemTypeCertificate, Bytes: intermediate.Raw}))
-			}
-		}
-
-		env.Signatures = append(env.Signatures, dsseSig)
-	}
-
-	return env, nil
-}
-
-type VerificationOption func(*verificationOptions)
-
-type verificationOptions struct {
-	roots         []*x509.Certificate
-	intermediates []*x509.Certificate
-	verifiers     []cryptoutil.Verifier
-	threshold     int
-}
-
-func WithRoots(roots []*x509.Certificate) VerificationOption {
-	return func(vo *verificationOptions) {
-		vo.roots = roots
-	}
-}
-
-func WithIntermediates(intermediates []*x509.Certificate) VerificationOption {
-	return func(vo *verificationOptions) {
-		vo.intermediates = intermediates
-	}
-}
-
-func WithVerifiers(verifiers []cryptoutil.Verifier) VerificationOption {
-	return func(vo *verificationOptions) {
-		vo.verifiers = verifiers
-	}
-}
-
-func WithThreshold(threshold int) VerificationOption {
-	return func(vo *verificationOptions) {
-		vo.threshold = threshold
-	}
-}
-
-func (e Envelope) Verify(opts ...VerificationOption) ([]cryptoutil.Verifier, error) {
-	options := &verificationOptions{
-		threshold: 1,
-	}
-
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	if options.threshold <= 0 {
-		return nil, ErrInvalidThreshold(options.threshold)
-	}
-
-	pae := preauthEncode(e.PayloadType, e.Payload)
-	if len(e.Signatures) == 0 {
-		return nil, ErrNoSignatures{}
-	}
-
-	matchingSigFound := false
-	passedVerifiers := make([]cryptoutil.Verifier, 0)
-	for _, sig := range e.Signatures {
-		if sig.Certificate != nil && len(sig.Certificate) > 0 {
-			cert, err := TryParseCertificate(sig.Certificate)
-			if err != nil {
-				continue
-			}
-
-			sigIntermediates := make([]*x509.Certificate, 0)
-			for _, int := range sig.Intermediates {
-				intCert, err := TryParseCertificate(int)
-				if err != nil {
-					continue
-				}
-
-				sigIntermediates = append(sigIntermediates, intCert)
-			}
-
-			sigIntermediates = append(sigIntermediates, options.intermediates...)
-			verifier, err := cryptoutil.NewX509Verifier(cert, sigIntermediates, options.roots, sig.trustedTime)
-			if err != nil {
-				return nil, err
-			}
-
-			if err := verifier.Verify(bytes.NewReader(pae), sig.Signature); err == nil {
-				passedVerifiers = append(passedVerifiers, verifier)
-				matchingSigFound = true
-			}
-		}
-
-		for _, verifier := range options.verifiers {
-			if verifier != nil {
-				if err := verifier.Verify(bytes.NewReader(pae), sig.Signature); err == nil {
-					passedVerifiers = append(passedVerifiers, verifier)
-					matchingSigFound = true
-				}
-			}
-		}
-	}
-
-	if !matchingSigFound {
-		return nil, ErrNoMatchingSigs{}
-	}
-
-	if len(passedVerifiers) < options.threshold {
-		return passedVerifiers, ErrThresholdNotMet{Theshold: options.threshold, Acutal: len(passedVerifiers)}
-	}
-
-	return passedVerifiers, nil
-}
-
-func TryParseCertificate(data []byte) (*x509.Certificate, error) {
-	possibleCert, err := cryptoutil.TryParseKeyFromReader(bytes.NewReader(data))
-	if err != nil {
-		return nil, err
-	}
-
-	cert, ok := possibleCert.(*x509.Certificate)
-	if !ok {
-		return nil, fmt.Errorf("data was a valid verifier but not a certificate")
-	}
-
-	return cert, nil
-}
-
-type SignatureOption func(so *signatureOptions)
-
-type signatureOptions struct {
-	cert          []byte
-	intermediates [][]byte
-	trustedTime   time.Time
-}
-
-func SignatureWithCertificate(certBytes []byte) SignatureOption {
-	return func(so *signatureOptions) {
-		so.cert = certBytes
-	}
-}
-
-func SignatureWithIntermediates(intermediates [][]byte) SignatureOption {
-	return func(so *signatureOptions) {
-		so.intermediates = intermediates
-	}
-}
-func SignatureWithTrustedTime(trustedTime time.Time) SignatureOption {
-	return func(so *signatureOptions) {
-		so.trustedTime = trustedTime
-	}
-}
-func NewSignature(keyID string, sig []byte, opts ...SignatureOption) Signature {
-	so := signatureOptions{}
-	for _, opt := range opts {
-		opt(&so)
-	}
-
-	return Signature{
-		KeyID:         keyID,
-		Signature:     sig,
-		Certificate:   so.cert,
-		Intermediates: so.intermediates,
-		trustedTime:   so.trustedTime,
-	}
 }

--- a/dsse/dsse_test.go
+++ b/dsse/dsse_test.go
@@ -16,45 +16,145 @@ package dsse
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testifysec/go-witness/cryptoutil"
 )
 
-func createTestKey() (cryptoutil.Signer, cryptoutil.Verifier, error) {
+func createRsaKey() (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	signer := cryptoutil.NewRSASigner(privKey, crypto.SHA256)
-	verifier := cryptoutil.NewRSAVerifier(&privKey.PublicKey, crypto.SHA256)
+	return privKey, &privKey.PublicKey, nil
+}
+
+func createTestKey() (cryptoutil.Signer, cryptoutil.Verifier, error) {
+	privKey, pubKey, err := createRsaKey()
 	if err != nil {
 		return nil, nil, err
 	}
 
+	signer := cryptoutil.NewRSASigner(privKey, crypto.SHA256)
+	verifier := cryptoutil.NewRSAVerifier(pubKey, crypto.SHA256)
 	return signer, verifier, nil
+}
+
+func createCert(priv, pub interface{}, temp, parent *x509.Certificate) (*x509.Certificate, error) {
+	var err error
+	temp.SerialNumber, err = rand.Int(rand.Reader, big.NewInt(4294967295))
+	if err != nil {
+		return nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, temp, parent, pub, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	return x509.ParseCertificate(certBytes)
+}
+
+func createRoot() (*x509.Certificate, interface{}, error) {
+	priv, pub, err := createRsaKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Organization: []string{"TestifySec"},
+			CommonName:   "Test Root",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        false,
+		MaxPathLen:            2,
+	}
+
+	cert, err := createCert(priv, pub, template, template)
+	return cert, priv, err
+}
+
+func createIntermediate(parent *x509.Certificate, parentPriv interface{}) (*x509.Certificate, interface{}, error) {
+	priv, pub, err := createRsaKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Organization: []string{"TestifySec"},
+			CommonName:   "Test Intermediate",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        false,
+		MaxPathLen:            1,
+	}
+
+	cert, err := createCert(parentPriv, pub, template, parent)
+	return cert, priv, err
+}
+
+func createLeaf(parent *x509.Certificate, parentPriv interface{}) (*x509.Certificate, interface{}, error) {
+	priv, pub, err := createRsaKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Organization: []string{"TestifySec"},
+			CommonName:   "Test Leaf",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	cert, err := createCert(parentPriv, pub, template, parent)
+	return cert, priv, err
 }
 
 func TestSign(t *testing.T) {
 	signer, _, err := createTestKey()
 	require.NoError(t, err)
-	_, err = Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signer)
+	_, err = Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), SignWithSigners(signer))
 	require.NoError(t, err)
 }
 
 func TestVerify(t *testing.T) {
 	signer, verifier, err := createTestKey()
 	require.NoError(t, err)
-	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signer)
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), SignWithSigners(signer))
 	require.NoError(t, err)
-	approvedVerifiers, err := env.Verify(WithVerifiers([]cryptoutil.Verifier{verifier}))
-	assert.ElementsMatch(t, approvedVerifiers, []cryptoutil.Verifier{verifier})
+	approvedVerifiers, err := env.Verify(VerifyWithVerifiers(verifier))
+	assert.ElementsMatch(t, approvedVerifiers, []PassedVerifier{{Verifier: verifier}})
 	require.NoError(t, err)
 }
 
@@ -63,9 +163,9 @@ func TestFailVerify(t *testing.T) {
 	require.NoError(t, err)
 	_, verifier, err := createTestKey()
 	require.NoError(t, err)
-	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signer)
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), SignWithSigners(signer))
 	require.NoError(t, err)
-	approvedVerifiers, err := env.Verify(WithVerifiers([]cryptoutil.Verifier{verifier}))
+	approvedVerifiers, err := env.Verify(VerifyWithVerifiers(verifier))
 	assert.Empty(t, approvedVerifiers)
 	require.ErrorIs(t, err, ErrNoMatchingSigs{})
 }
@@ -73,30 +173,32 @@ func TestFailVerify(t *testing.T) {
 func TestMultiSigners(t *testing.T) {
 	signers := []cryptoutil.Signer{}
 	verifiers := []cryptoutil.Verifier{}
+	expectedVerifiers := []PassedVerifier{}
 	for i := 0; i < 5; i++ {
 		s, v, err := createTestKey()
 		require.NoError(t, err)
 		signers = append(signers, s)
 		verifiers = append(verifiers, v)
+		expectedVerifiers = append(expectedVerifiers, PassedVerifier{Verifier: v})
 	}
 
-	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signers...)
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), SignWithSigners(signers...))
 	require.NoError(t, err)
 
-	approvedVerifiers, err := env.Verify(WithVerifiers(verifiers))
+	approvedVerifiers, err := env.Verify(VerifyWithVerifiers(verifiers...))
 	require.NoError(t, err)
-	assert.ElementsMatch(t, approvedVerifiers, verifiers)
+	assert.ElementsMatch(t, approvedVerifiers, expectedVerifiers)
 }
 
 func TestThreshold(t *testing.T) {
 	signers := []cryptoutil.Signer{}
-	expectedVerifiers := []cryptoutil.Verifier{}
+	expectedVerifiers := []PassedVerifier{}
 	verifiers := []cryptoutil.Verifier{}
 	for i := 0; i < 5; i++ {
 		s, v, err := createTestKey()
 		require.NoError(t, err)
 		signers = append(signers, s)
-		expectedVerifiers = append(expectedVerifiers, v)
+		expectedVerifiers = append(expectedVerifiers, PassedVerifier{Verifier: v})
 		verifiers = append(verifiers, v)
 	}
 
@@ -107,17 +209,80 @@ func TestThreshold(t *testing.T) {
 		verifiers = append(verifiers, v)
 	}
 
-	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), signers...)
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), SignWithSigners(signers...))
 	require.NoError(t, err)
 
-	approvedVerifiers, err := env.Verify(WithVerifiers(verifiers), WithThreshold(5))
+	approvedVerifiers, err := env.Verify(VerifyWithVerifiers(verifiers...), VerifyWithThreshold(5))
 	require.NoError(t, err)
 	assert.ElementsMatch(t, approvedVerifiers, expectedVerifiers)
 
-	approvedVerifiers, err = env.Verify(WithVerifiers(verifiers), WithThreshold(10))
+	approvedVerifiers, err = env.Verify(VerifyWithVerifiers(verifiers...), VerifyWithThreshold(10))
 	require.ErrorIs(t, err, ErrThresholdNotMet{Acutal: 5, Theshold: 10})
 	assert.ElementsMatch(t, approvedVerifiers, expectedVerifiers)
 
-	_, err = env.Verify(WithVerifiers(verifiers), WithThreshold(-10))
+	_, err = env.Verify(VerifyWithVerifiers(verifiers...), VerifyWithThreshold(-10))
 	require.ErrorIs(t, err, ErrInvalidThreshold(-10))
+}
+
+func TestTimestamp(t *testing.T) {
+	root, rootPriv, err := createRoot()
+	require.NoError(t, err)
+	intermediate, intermediatePriv, err := createIntermediate(root, rootPriv)
+	require.NoError(t, err)
+	leaf, leafPriv, err := createLeaf(intermediate, intermediatePriv)
+	require.NoError(t, err)
+	s, err := cryptoutil.NewSigner(leafPriv, cryptoutil.SignWithCertificate(leaf))
+	require.NoError(t, err)
+	v, err := s.Verifier()
+	require.NoError(t, err)
+	expectedTimestampers := []dummyTimestamper{
+		{t: time.Now()},
+		{t: time.Now().Add(12 * time.Hour)},
+	}
+	unexpectedTimestampers := []dummyTimestamper{
+		{t: time.Now().Add(36 * time.Hour)},
+		{t: time.Now().Add(128 * time.Hour)},
+	}
+
+	allTimestampers := make([]Timestamper, 0)
+	allTimestampVerifiers := make([]TimestampVerifier, 0)
+	for _, expected := range expectedTimestampers {
+		allTimestampers = append(allTimestampers, expected)
+		allTimestampVerifiers = append(allTimestampVerifiers, expected)
+	}
+
+	for _, unexpected := range unexpectedTimestampers {
+		allTimestampers = append(allTimestampers, unexpected)
+		allTimestampVerifiers = append(allTimestampVerifiers, unexpected)
+	}
+
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), SignWithSigners(s), SignWithTimestampers(allTimestampers...))
+	require.NoError(t, err)
+
+	approvedVerifiers, err := env.Verify(VerifyWithVerifiers(v), VerifyWithRoots(root), VerifyWithIntermediates(intermediate), VerifyWithTimestampVerifiers(allTimestampVerifiers...))
+	require.NoError(t, err)
+	assert.Len(t, approvedVerifiers, 1)
+	assert.Len(t, approvedVerifiers[0].PassedTimestampVerifiers, len(expectedTimestampers))
+	assert.ElementsMatch(t, approvedVerifiers[0].PassedTimestampVerifiers, expectedTimestampers)
+}
+
+type dummyTimestamper struct {
+	t time.Time
+}
+
+func (dt dummyTimestamper) Timestamp(context.Context, io.Reader) ([]byte, error) {
+	return []byte(dt.t.Format(time.RFC3339)), nil
+}
+
+func (dt dummyTimestamper) Verify(ctx context.Context, ts io.Reader, sig io.Reader) (time.Time, error) {
+	b, err := io.ReadAll(ts)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if string(b) != dt.t.Format(time.RFC3339) {
+		return time.Time{}, fmt.Errorf("mismatched time")
+	}
+
+	return dt.t, nil
 }

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -1,0 +1,109 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dsse
+
+import (
+	"bytes"
+	"context"
+	"encoding/pem"
+	"io"
+
+	"github.com/testifysec/go-witness/cryptoutil"
+)
+
+type Timestamper interface {
+	Timestamp(context.Context, io.Reader) ([]byte, error)
+}
+
+type signOptions struct {
+	signers      []cryptoutil.Signer
+	timestampers []Timestamper
+}
+
+type SignOption func(*signOptions)
+
+func SignWithSigners(signers ...cryptoutil.Signer) SignOption {
+	return func(so *signOptions) {
+		so.signers = signers
+	}
+}
+
+func SignWithTimestampers(timestampers ...Timestamper) SignOption {
+	return func(so *signOptions) {
+		so.timestampers = timestampers
+	}
+}
+
+func Sign(bodyType string, body io.Reader, opts ...SignOption) (Envelope, error) {
+	so := &signOptions{}
+	for _, opt := range opts {
+		opt(so)
+	}
+
+	env := Envelope{}
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return env, err
+	}
+
+	env.PayloadType = bodyType
+	env.Payload = bodyBytes
+	env.Signatures = make([]Signature, 0)
+	pae := preauthEncode(bodyType, bodyBytes)
+	for _, signer := range so.signers {
+		sig, err := signer.Sign(bytes.NewReader(pae))
+		if err != nil {
+			return env, err
+		}
+
+		keyID, err := signer.KeyID()
+		if err != nil {
+			return env, err
+		}
+
+		dsseSig := Signature{
+			KeyID:     keyID,
+			Signature: sig,
+		}
+
+		for _, timestamper := range so.timestampers {
+			timestamp, err := timestamper.Timestamp(context.TODO(), bytes.NewReader(sig))
+			if err != nil {
+				return env, err
+			}
+
+			dsseSig.Timestamps = append(dsseSig.Timestamps, SignatureTimestamp{
+				Type: TimestampRFC3161,
+				Data: timestamp,
+			})
+		}
+
+		if trustBundler, ok := signer.(cryptoutil.TrustBundler); ok {
+			leaf := trustBundler.Certificate()
+			intermediates := trustBundler.Intermediates()
+			if leaf != nil {
+				dsseSig.Certificate = pem.EncodeToMemory(&pem.Block{Type: PemTypeCertificate, Bytes: leaf.Raw})
+			}
+
+			for _, intermediate := range intermediates {
+				dsseSig.Intermediates = append(dsseSig.Intermediates, pem.EncodeToMemory(&pem.Block{Type: PemTypeCertificate, Bytes: intermediate.Raw}))
+			}
+		}
+
+		env.Signatures = append(env.Signatures, dsseSig)
+	}
+
+	return env, nil
+}

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -1,0 +1,179 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dsse
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"io"
+	"time"
+
+	"github.com/testifysec/go-witness/cryptoutil"
+)
+
+type TimestampVerifier interface {
+	Verify(context.Context, io.Reader, io.Reader) (time.Time, error)
+}
+
+type verificationOptions struct {
+	roots              []*x509.Certificate
+	intermediates      []*x509.Certificate
+	verifiers          []cryptoutil.Verifier
+	threshold          int
+	timestampVerifiers []TimestampVerifier
+}
+
+type VerificationOption func(*verificationOptions)
+
+func VerifyWithRoots(roots ...*x509.Certificate) VerificationOption {
+	return func(vo *verificationOptions) {
+		vo.roots = roots
+	}
+}
+
+func VerifyWithIntermediates(intermediates ...*x509.Certificate) VerificationOption {
+	return func(vo *verificationOptions) {
+		vo.intermediates = intermediates
+	}
+}
+
+func VerifyWithVerifiers(verifiers ...cryptoutil.Verifier) VerificationOption {
+	return func(vo *verificationOptions) {
+		vo.verifiers = verifiers
+	}
+}
+
+func VerifyWithThreshold(threshold int) VerificationOption {
+	return func(vo *verificationOptions) {
+		vo.threshold = threshold
+	}
+}
+
+func VerifyWithTimestampVerifiers(verifiers ...TimestampVerifier) VerificationOption {
+	return func(vo *verificationOptions) {
+		vo.timestampVerifiers = verifiers
+	}
+}
+
+type PassedVerifier struct {
+	Verifier                 cryptoutil.Verifier
+	PassedTimestampVerifiers []TimestampVerifier
+}
+
+func (e Envelope) Verify(opts ...VerificationOption) ([]PassedVerifier, error) {
+	options := &verificationOptions{
+		threshold: 1,
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.threshold <= 0 {
+		return nil, ErrInvalidThreshold(options.threshold)
+	}
+
+	pae := preauthEncode(e.PayloadType, e.Payload)
+	if len(e.Signatures) == 0 {
+		return nil, ErrNoSignatures{}
+	}
+
+	matchingSigFound := false
+	passedVerifiers := make([]PassedVerifier, 0)
+	for _, sig := range e.Signatures {
+		if sig.Certificate != nil && len(sig.Certificate) > 0 {
+			cert, err := cryptoutil.TryParseCertificate(sig.Certificate)
+			if err != nil {
+				continue
+			}
+
+			sigIntermediates := make([]*x509.Certificate, 0)
+			for _, int := range sig.Intermediates {
+				intCert, err := cryptoutil.TryParseCertificate(int)
+				if err != nil {
+					continue
+				}
+
+				sigIntermediates = append(sigIntermediates, intCert)
+			}
+
+			sigIntermediates = append(sigIntermediates, options.intermediates...)
+			if len(options.timestampVerifiers) == 0 {
+				if verifier, err := verifyX509Time(cert, sigIntermediates, options.roots, pae, sig.Signature, time.Now()); err == nil {
+					matchingSigFound = true
+					passedVerifiers = append(passedVerifiers, PassedVerifier{Verifier: verifier})
+				}
+			} else {
+				var passedVerifier cryptoutil.Verifier
+				passedTimestampVerifiers := []TimestampVerifier{}
+
+				for _, timestampVerifier := range options.timestampVerifiers {
+					for _, sigTimestamp := range sig.Timestamps {
+						timestamp, err := timestampVerifier.Verify(context.TODO(), bytes.NewReader(sigTimestamp.Data), bytes.NewReader(sig.Signature))
+						if err != nil {
+							continue
+						}
+
+						if verifier, err := verifyX509Time(cert, sigIntermediates, options.roots, pae, sig.Signature, timestamp); err == nil {
+							passedVerifier = verifier
+							passedTimestampVerifiers = append(passedTimestampVerifiers, timestampVerifier)
+						}
+					}
+				}
+
+				if len(passedTimestampVerifiers) > 0 {
+					matchingSigFound = true
+					passedVerifiers = append(passedVerifiers, PassedVerifier{
+						Verifier:                 passedVerifier,
+						PassedTimestampVerifiers: passedTimestampVerifiers,
+					})
+				}
+			}
+		}
+
+		for _, verifier := range options.verifiers {
+			if verifier != nil {
+				if err := verifier.Verify(bytes.NewReader(pae), sig.Signature); err == nil {
+					passedVerifiers = append(passedVerifiers, PassedVerifier{Verifier: verifier})
+					matchingSigFound = true
+				}
+			}
+		}
+	}
+
+	if !matchingSigFound {
+		return nil, ErrNoMatchingSigs{}
+	}
+
+	if len(passedVerifiers) < options.threshold {
+		return passedVerifiers, ErrThresholdNotMet{Theshold: options.threshold, Acutal: len(passedVerifiers)}
+	}
+
+	return passedVerifiers, nil
+}
+
+func verifyX509Time(cert *x509.Certificate, sigIntermediates, roots []*x509.Certificate, pae, sig []byte, trustedTime time.Time) (cryptoutil.Verifier, error) {
+	verifier, err := cryptoutil.NewX509Verifier(cert, sigIntermediates, roots, trustedTime)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := verifier.Verify(bytes.NewReader(pae), sig); err != nil {
+		return nil, err
+	}
+
+	return verifier, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/anchore/stereoscope v0.0.0-20220708133445-777471f38c5b
 	github.com/anchore/syft v0.53.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/digitorus/timestamp v0.0.0-20220704143351-8225fba02d52
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/open-policy-agent/opa v0.43.1
 	github.com/owenrumney/go-sarif v1.1.1
@@ -36,6 +37,7 @@ require (
 	github.com/containerd/containerd v1.6.6 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.12.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.2.0 // indirect
+	github.com/digitorus/pkcs7 v0.0.0-20220704143225-a9c8106cbfc6 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.17+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,6 +451,10 @@ github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUn
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/digitorus/pkcs7 v0.0.0-20220704143225-a9c8106cbfc6 h1:b98clxJQS08ohZb7PuAqYJw6WvIJGcAWoUVPgOHwNw0=
+github.com/digitorus/pkcs7 v0.0.0-20220704143225-a9c8106cbfc6/go.mod h1:ajT9Iifwrck892Z07+wD+dRRv9ULmlmPG0A+OHSrDuQ=
+github.com/digitorus/timestamp v0.0.0-20220704143351-8225fba02d52 h1:8yE7SkzxCSHuu6++s3P2lJJZGLLS8Q5uL3MMwK3wD/U=
+github.com/digitorus/timestamp v0.0.0-20220704143351-8225fba02d52/go.mod h1:pSqPNzhOhJrn3N5w7GvPHUuaGa7pPf4cKNm57fGLe2E=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/distribution/distribution/v3 v3.0.0-20220526142353-ffbd94cbe269/go.mod h1:28YO/VJk9/64+sTGNuYaBjWxrXTPrj0C0XmgTIOjxX4=

--- a/run.go
+++ b/run.go
@@ -151,5 +151,5 @@ func signCollection(collection attestation.Collection, signer cryptoutil.Signer)
 		return dsse.Envelope{}, err
 	}
 
-	return dsse.Sign(intoto.PayloadType, bytes.NewReader(stmtJson), signer)
+	return dsse.Sign(intoto.PayloadType, bytes.NewReader(stmtJson), dsse.SignWithSigners(signer))
 }

--- a/sign.go
+++ b/sign.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Sign(r io.Reader, dataType string, w io.Writer, signers ...cryptoutil.Signer) error {
-	env, err := dsse.Sign(dataType, r, signers...)
+	env, err := dsse.Sign(dataType, r, dsse.SignWithSigners(signers...))
 	if err != nil {
 		return err
 	}

--- a/source/verified.go
+++ b/source/verified.go
@@ -48,10 +48,15 @@ func (s *VerifiedSource) Search(ctx context.Context, collectionName string, subj
 
 	verified := make([]VerifiedCollection, 0)
 	for _, toVerify := range unverified {
-		passedVerifiers, err := toVerify.Envelope.Verify(s.verifyOpts...)
+		envelopeVerifiers, err := toVerify.Envelope.Verify(s.verifyOpts...)
 		if err != nil {
 			log.Debugf("(verified source) skipping envelope: couldn't verify enveloper's signature with the policy's verifiers: %+v", err)
 			continue
+		}
+
+		passedVerifiers := make([]cryptoutil.Verifier, 0)
+		for _, verifier := range envelopeVerifiers {
+			passedVerifiers = append(passedVerifiers, verifier.Verifier)
 		}
 
 		verified = append(verified, VerifiedCollection{

--- a/timestamp/tsp.go
+++ b/timestamp/tsp.go
@@ -1,0 +1,174 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timestamp
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/digitorus/pkcs7"
+	"github.com/digitorus/timestamp"
+	"github.com/testifysec/go-witness/cryptoutil"
+)
+
+type TSPTimestamper struct {
+	url                string
+	hash               crypto.Hash
+	requestCertificate bool
+}
+
+type TSPTimestamperOption func(*TSPTimestamper)
+
+func TimestampWithUrl(url string) TSPTimestamperOption {
+	return func(t *TSPTimestamper) {
+		t.url = url
+	}
+}
+
+func TimestampWithHash(h crypto.Hash) TSPTimestamperOption {
+	return func(t *TSPTimestamper) {
+		t.hash = h
+	}
+}
+
+func TimestampWithRequestCertificate(requestCertificate bool) TSPTimestamperOption {
+	return func(t *TSPTimestamper) {
+		t.requestCertificate = requestCertificate
+	}
+}
+
+func NewTimestamper(opts ...TSPTimestamperOption) TSPTimestamper {
+	t := TSPTimestamper{
+		hash:               crypto.SHA256,
+		requestCertificate: true,
+	}
+
+	for _, opt := range opts {
+		opt(&t)
+	}
+
+	return t
+}
+
+func (t TSPTimestamper) Timestamp(ctx context.Context, r io.Reader) ([]byte, error) {
+	tsq, err := timestamp.CreateRequest(r, &timestamp.RequestOptions{
+		Hash:         t.hash,
+		Certificates: t.requestCertificate,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", t.url, bytes.NewReader(tsq))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/timestamp-query")
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request to timestamp authority failed: %v", resp.Status)
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp, err := timestamp.ParseResponse(bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return timestamp.RawToken, nil
+}
+
+type TSPVerifier struct {
+	certChain *x509.CertPool
+	hash      crypto.Hash
+}
+
+type TSPVerifierOption func(*TSPVerifier)
+
+func VerifyWithCerts(certs []*x509.Certificate) TSPVerifierOption {
+	return func(t *TSPVerifier) {
+		t.certChain = x509.NewCertPool()
+		for _, cert := range certs {
+			t.certChain.AddCert(cert)
+		}
+	}
+}
+
+func VerifyWithHash(h crypto.Hash) TSPVerifierOption {
+	return func(t *TSPVerifier) {
+		t.hash = h
+	}
+}
+
+func NewVerifier(opts ...TSPVerifierOption) TSPVerifier {
+	v := TSPVerifier{
+		hash: crypto.SHA256,
+	}
+
+	for _, opt := range opts {
+		opt(&v)
+	}
+
+	return v
+}
+
+func (v TSPVerifier) Verify(ctx context.Context, tsrData, signedData io.Reader) (time.Time, error) {
+	tsrBytes, err := io.ReadAll(tsrData)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	ts, err := timestamp.Parse(tsrBytes)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	hashedData, err := cryptoutil.Digest(signedData, v.hash)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if !bytes.Equal(ts.HashedMessage, hashedData) {
+		return time.Time{}, fmt.Errorf("signed payload does not match timestamped payload")
+	}
+
+	p7, err := pkcs7.Parse(tsrBytes)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if err := p7.VerifyWithChain(v.certChain); err != nil {
+		return time.Time{}, err
+	}
+
+	return ts.Time, nil
+}

--- a/timestamp/tsp_test.go
+++ b/timestamp/tsp_test.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timestamp
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testifysec/go-witness/cryptoutil"
+)
+
+const (
+	tsaUrl = "https://freetsa.org/tsr"
+	tsaCA  = `-----BEGIN CERTIFICATE-----
+MIIH/zCCBeegAwIBAgIJAMHphhYNqOmAMA0GCSqGSIb3DQEBDQUAMIGVMREwDwYD
+VQQKEwhGcmVlIFRTQTEQMA4GA1UECxMHUm9vdCBDQTEYMBYGA1UEAxMPd3d3LmZy
+ZWV0c2Eub3JnMSIwIAYJKoZIhvcNAQkBFhNidXNpbGV6YXNAZ21haWwuY29tMRIw
+EAYDVQQHEwlXdWVyemJ1cmcxDzANBgNVBAgTBkJheWVybjELMAkGA1UEBhMCREUw
+HhcNMTYwMzEzMDE1MjEzWhcNNDEwMzA3MDE1MjEzWjCBlTERMA8GA1UEChMIRnJl
+ZSBUU0ExEDAOBgNVBAsTB1Jvb3QgQ0ExGDAWBgNVBAMTD3d3dy5mcmVldHNhLm9y
+ZzEiMCAGCSqGSIb3DQEJARYTYnVzaWxlemFzQGdtYWlsLmNvbTESMBAGA1UEBxMJ
+V3VlcnpidXJnMQ8wDQYDVQQIEwZCYXllcm4xCzAJBgNVBAYTAkRFMIICIjANBgkq
+hkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAtgKODjAy8REQ2WTNqUudAnjhlCrpE6ql
+mQfNppeTmVvZrH4zutn+NwTaHAGpjSGv4/WRpZ1wZ3BRZ5mPUBZyLgq0YrIfQ5Fx
+0s/MRZPzc1r3lKWrMR9sAQx4mN4z11xFEO529L0dFJjPF9MD8Gpd2feWzGyptlel
+b+PqT+++fOa2oY0+NaMM7l/xcNHPOaMz0/2olk0i22hbKeVhvokPCqhFhzsuhKsm
+q4Of/o+t6dI7sx5h0nPMm4gGSRhfq+z6BTRgCrqQG2FOLoVFgt6iIm/BnNffUr7V
+DYd3zZmIwFOj/H3DKHoGik/xK3E82YA2ZulVOFRW/zj4ApjPa5OFbpIkd0pmzxzd
+EcL479hSA9dFiyVmSxPtY5ze1P+BE9bMU1PScpRzw8MHFXxyKqW13Qv7LWw4sbk3
+SciB7GACbQiVGzgkvXG6y85HOuvWNvC5GLSiyP9GlPB0V68tbxz4JVTRdw/Xn/XT
+FNzRBM3cq8lBOAVt/PAX5+uFcv1S9wFE8YjaBfWCP1jdBil+c4e+0tdywT2oJmYB
+BF/kEt1wmGwMmHunNEuQNzh1FtJY54hbUfiWi38mASE7xMtMhfj/C4SvapiDN837
+gYaPfs8x3KZxbX7C3YAsFnJinlwAUss1fdKar8Q/YVs7H/nU4c4Ixxxz4f67fcVq
+M2ITKentbCMCAwEAAaOCAk4wggJKMAwGA1UdEwQFMAMBAf8wDgYDVR0PAQH/BAQD
+AgHGMB0GA1UdDgQWBBT6VQ2MNGZRQ0z357OnbJWveuaklzCBygYDVR0jBIHCMIG/
+gBT6VQ2MNGZRQ0z357OnbJWveuakl6GBm6SBmDCBlTERMA8GA1UEChMIRnJlZSBU
+U0ExEDAOBgNVBAsTB1Jvb3QgQ0ExGDAWBgNVBAMTD3d3dy5mcmVldHNhLm9yZzEi
+MCAGCSqGSIb3DQEJARYTYnVzaWxlemFzQGdtYWlsLmNvbTESMBAGA1UEBxMJV3Vl
+cnpidXJnMQ8wDQYDVQQIEwZCYXllcm4xCzAJBgNVBAYTAkRFggkAwemGFg2o6YAw
+MwYDVR0fBCwwKjAooCagJIYiaHR0cDovL3d3dy5mcmVldHNhLm9yZy9yb290X2Nh
+LmNybDCBzwYDVR0gBIHHMIHEMIHBBgorBgEEAYHyJAEBMIGyMDMGCCsGAQUFBwIB
+FidodHRwOi8vd3d3LmZyZWV0c2Eub3JnL2ZyZWV0c2FfY3BzLmh0bWwwMgYIKwYB
+BQUHAgEWJmh0dHA6Ly93d3cuZnJlZXRzYS5vcmcvZnJlZXRzYV9jcHMucGRmMEcG
+CCsGAQUFBwICMDsaOUZyZWVUU0EgdHJ1c3RlZCB0aW1lc3RhbXBpbmcgU29mdHdh
+cmUgYXMgYSBTZXJ2aWNlIChTYWFTKTA3BggrBgEFBQcBAQQrMCkwJwYIKwYBBQUH
+MAGGG2h0dHA6Ly93d3cuZnJlZXRzYS5vcmc6MjU2MDANBgkqhkiG9w0BAQ0FAAOC
+AgEAaK9+v5OFYu9M6ztYC+L69sw1omdyli89lZAfpWMMh9CRmJhM6KBqM/ipwoLt
+nxyxGsbCPhcQjuTvzm+ylN6VwTMmIlVyVSLKYZcdSjt/eCUN+41K7sD7GVmxZBAF
+ILnBDmTGJmLkrU0KuuIpj8lI/E6Z6NnmuP2+RAQSHsfBQi6sssnXMo4HOW5gtPO7
+gDrUpVXID++1P4XndkoKn7Svw5n0zS9fv1hxBcYIHPPQUze2u30bAQt0n0iIyRLz
+aWuhtpAtd7ffwEbASgzB7E+NGF4tpV37e8KiA2xiGSRqT5ndu28fgpOY87gD3ArZ
+DctZvvTCfHdAS5kEO3gnGGeZEVLDmfEsv8TGJa3AljVa5E40IQDsUXpQLi8G+UC4
+1DWZu8EVT4rnYaCw1VX7ShOR1PNCCvjb8S8tfdudd9zhU3gEB0rxdeTy1tVbNLXW
+99y90xcwr1ZIDUwM/xQ/noO8FRhm0LoPC73Ef+J4ZBdrvWwauF3zJe33d4ibxEcb
+8/pz5WzFkeixYM2nsHhqHsBKw7JPouKNXRnl5IAE1eFmqDyC7G/VT7OF669xM6hb
+Ut5G21JE4cNK6NNucS+fzg1JPX0+3VhsYZjj7D5uljRvQXrJ8iHgr/M6j2oLHvTA
+I2MLdq2qjZFDOCXsxBxJpbmLGBx9ow6ZerlUxzws2AWv2pk=
+-----END CERTIFICATE-----`
+	otherCA = `-----BEGIN CERTIFICATE-----
+MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQswCQYDVQQGEwJVUzET
+MBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlv
+biBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwHhcNMDYwNDI1MjE0
+MDM2WhcNMzUwMjA5MjE0MDM2WjBiMQswCQYDVQQGEwJVUzETMBEGA1UEChMKQXBw
+bGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkx
+FjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+ggEKAoIBAQDkkakJH5HbHkdQ6wXtXnmELes2oldMVeyLGYne+Uts9QerIjAC6Bg+
++FAJ039BqJj50cpmnCRrEdCju+QbKsMflZ56DKRHi1vUFjczy8QPTc4UadHJGXL1
+XQ7Vf1+b8iUDulWPTV0N8WQ1IxVLFVkds5T39pyez1C6wVhQZ48ItCD3y6wsIG9w
+tj8BMIy3Q88PnT3zK0koGsj+zrW5DtleHNbLPbU6rfQPDgCSC7EhFi501TwN22IW
+q6NxkkdTVcGvL0Gz+PvjcM3mo0xFfh9Ma1CWQYnEdGILEINBhzOKgbEwWOxaBDKM
+aLOPHd5lc/9nXmW8Sdh2nzMUZaF3lMktAgMBAAGjggF6MIIBdjAOBgNVHQ8BAf8E
+BAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUK9BpR5R2Cf70a40uQKb3
+R01/CF4wHwYDVR0jBBgwFoAUK9BpR5R2Cf70a40uQKb3R01/CF4wggERBgNVHSAE
+ggEIMIIBBDCCAQAGCSqGSIb3Y2QFATCB8jAqBggrBgEFBQcCARYeaHR0cHM6Ly93
+d3cuYXBwbGUuY29tL2FwcGxlY2EvMIHDBggrBgEFBQcCAjCBthqBs1JlbGlhbmNl
+IG9uIHRoaXMgY2VydGlmaWNhdGUgYnkgYW55IHBhcnR5IGFzc3VtZXMgYWNjZXB0
+YW5jZSBvZiB0aGUgdGhlbiBhcHBsaWNhYmxlIHN0YW5kYXJkIHRlcm1zIGFuZCBj
+b25kaXRpb25zIG9mIHVzZSwgY2VydGlmaWNhdGUgcG9saWN5IGFuZCBjZXJ0aWZp
+Y2F0aW9uIHByYWN0aWNlIHN0YXRlbWVudHMuMA0GCSqGSIb3DQEBBQUAA4IBAQBc
+NplMLXi37Yyb3PN3m/J20ncwT8EfhYOFG5k9RzfyqZtAjizUsZAS2L70c5vu0mQP
+y3lPNNiiPvl4/2vIB+x9OYOLUyDTOMSxv5pPCmv/K/xZpwUJfBdAVhEedNO3iyM7
+R6PVbyTi69G3cN8PReEnyvFteO3ntRcXqNx+IjXKJdXZD9Zr1KIkIxH3oayPc4Fg
+xhtbCS+SsvhESPBgOJ4V9T0mZyCKM2r3DYLP3uujL/lTaltkwGMzd/c6ByxW69oP
+IQ7aunMZT7XZNn/Bh1XZp5m5MkL72NVxnn6hUrcbvZNCJBIqxw8dtk2cXmPIS4AX
+UKqK1drk/NAJBzewdXUh
+-----END CERTIFICATE-----`
+)
+
+func TestTSP(t *testing.T) {
+	ts := NewTimestamper(TimestampWithUrl(tsaUrl))
+	payload := []byte("some data to timestamp")
+	resp, err := ts.Timestamp(context.Background(), bytes.NewReader(payload))
+	require.NoError(t, err)
+	cert, err := cryptoutil.TryParseCertificate([]byte(tsaCA))
+	require.NoError(t, err)
+	otherCert, err := cryptoutil.TryParseCertificate([]byte(otherCA))
+	require.NoError(t, err)
+	v := NewVerifier(VerifyWithCerts([]*x509.Certificate{cert}))
+
+	t.Run("pass", func(t *testing.T) {
+		signedTime, err := v.Verify(context.Background(), bytes.NewReader(resp), bytes.NewReader(payload))
+		assert.NoError(t, err)
+		assert.NotZero(t, signedTime)
+	})
+
+	t.Run("incorrect payload", func(t *testing.T) {
+		signedTime, err := v.Verify(context.Background(), bytes.NewReader(resp), bytes.NewReader([]byte("this is not what was timestamped")))
+		assert.Error(t, err)
+		assert.Zero(t, signedTime)
+	})
+
+	t.Run("incorrect cert", func(t *testing.T) {
+		v = NewVerifier(VerifyWithCerts([]*x509.Certificate{otherCert}))
+		signedTime, err := v.Verify(context.Background(), bytes.NewReader(resp), bytes.NewReader(payload))
+		assert.Error(t, err)
+		assert.Zero(t, signedTime)
+	})
+}


### PR DESCRIPTION
* Adds an array to the signatures on a dsse envelope representing
  timestamps of that signature
* Adds implementation of RFC3161 timestamps for signing and policy
  enforcement
* Adds policy support for ensuring signatures have timestamps from a
  trusted time stamp authority