### PR TITLE
fix: fixes bug where files under 512 bytes would cause EOF error

### DIFF
--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -36,7 +36,7 @@ const (
 	Type    = "https://witness.dev/attestations/oci/v0.1"
 	RunType = attestation.PostRunType
 
-	mimeTypes = "application/octet-stream application/x-tar"
+	mimeTypes = "application/x-tar"
 )
 
 // This is a hacky way to create a compile time error in case the attestor


### PR DESCRIPTION
This fixes the EOF error and some additional issues relating to small files discovered when I created some tests.

I added support for detecting pdf files to show the pattern which can be used when adding additional type detection.