### PR TITLE
feat: attestor config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![witness](/docs/assets/logo.png)
 
 [![asciicast](https://asciinema.org/a/2DZRRh8uzrzHcUVL8md86Zj4D.svg)](https://asciinema.org/a/2DZRRh8uzrzHcUVL8md86Zj4D)
 
@@ -201,13 +200,15 @@ Examples of cryptographic validation is found in the [GCP](https://github.com/te
 
 ## Attestor Life Cycle
 
-- **PreRun:** `PreRun` attestors run before the `material` attestor and `commandRun` attestors. These attestors generally collect information about the environment.
+- **Pre-material:** Pre-material attestors run before any other attestors. These attestors generally collect information about the environment.
 
-- **Material Attestor:** The `material` attestor is an internal attestor and runs immediately after
+- **Material:** Material attestors run after any prematerial attestors and prior to any execute attestors. Generally these collect information about state that may change after any execute attestors, such as file hashes.
 
-- **CommandRun Attestor:** The CommandRun attestor is an internal attestor. It has experimental tracing support that can be enabled with the `--trace` flag
+- **Execute:**: Execute attestors run after any material attestors and generally record information about some command or process that is to be executed.
 
-- **Product Attestor:** The Product attestor collects the products produced by the `commandRun` attestor and calculates the secure hash, and makes the file descriptor available to the `postRun` attestors.
+- **Product:** Product attestors run after any execute attestors and generally record information about what changed during the execute lifecycle step, such as changed or created files.
+
+- **Post-product:** Post-product attestors run after product attestors and generally record some additional information about specific products, such as OCI image information from a saved image tarball.
 
 ### Attestation Lifecycle
 
@@ -215,8 +216,7 @@ Examples of cryptographic validation is found in the [GCP](https://github.com/te
 
 ## Attestor Types
 
-### Pre Run Attestors
-
+### Pre-material Attestors
 - [AWS](docs/attestors/aws-iid.md) - Attestor for AWS Instance Metadata
 - [GCP](docs/attestors/gcp-iit.md) - Attestor for GCP Instance Identity Service
 - [GitLab](docs/attestors/gitlab.md) - Attestor for GitLab Pipelines
@@ -225,15 +225,16 @@ Examples of cryptographic validation is found in the [GCP](https://github.com/te
 - [Environment](docs/attestors/environment.md) - Attestor for environment variables (**_be careful with this - there is no way to mask values yet_**)
 - [JWT](docs/attestors/jwt.md) - Attestor for JWT Tokens
 
-### Internal Attestors
-
-- [CommandRun](docs/attestors/commandrun.md) - Records traces and metadata about the actual process being run
+### Material Attestors
 - [Material](docs/attestors/material.md) - Records secure hashes of files in current working directory
+
+### Execute Attestors
+- [CommandRun](docs/attestors/commandrun.md) - Records traces and metadata about the actual process being run
+
+### Product Attestors
 - [Product](docs/attestors/product.md) - Records secure hashes of files produced by commandrun attestor (only detects new files)
 
-### Post Run Attestors
-
-PostRun attestors collect have access to the files discovered by the product attestor. The purpose of PostRun attestors is to select metadata from the products. For example, in the OCI attestor the attestor examines the tar file and extracts OCI container meta-data.
+### Post-product Attestors
 
 - [OCI](docs/attestors/oci.md) - Attestor for tar'd OCI images
 

--- a/attestation/aws-iid/aws-iid.go
+++ b/attestation/aws-iid/aws-iid.go
@@ -35,7 +35,7 @@ import (
 const (
 	Name    = "aws"
 	Type    = "https://witness.dev/attestations/aws/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 )
 
 // These will be configurable in the future

--- a/attestation/commandrun/commandrun.go
+++ b/attestation/commandrun/commandrun.go
@@ -28,7 +28,7 @@ import (
 const (
 	Name    = "command-run"
 	Type    = "https://witness.dev/attestations/command-run/v0.1"
-	RunType = attestation.Internal
+	RunType = attestation.ExecuteRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/attestation/environment/environment.go
+++ b/attestation/environment/environment.go
@@ -26,7 +26,7 @@ import (
 const (
 	Name    = "environment"
 	Type    = "https://witness.dev/attestations/environment/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/attestation/factory_test.go
+++ b/attestation/factory_test.go
@@ -1,0 +1,138 @@
+// Copyright 2023 The Archivist Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry(t *testing.T) {
+	attestors := []dummyAttestor{
+		{
+			name:          "prerun",
+			predicateType: "https://witness.dev/test/prerun",
+			runType:       PreMaterialRunType,
+		}, {
+			name:          "execute",
+			predicateType: "https://witness.dev/test/execute",
+			runType:       ExecuteRunType,
+		},
+		{
+			name:          "post",
+			predicateType: "https://witness.dev/test/post",
+			runType:       PostProductRunType,
+		},
+	}
+
+	for _, attestor := range attestors {
+		RegisterAttestation(attestor.name, attestor.predicateType, attestor.runType, func() Attestor { return &attestor })
+	}
+
+	for _, attestor := range attestors {
+		factory, ok := FactoryByType(attestor.predicateType)
+		require.True(t, ok)
+		otherFactory, ok := FactoryByName(attestor.name)
+		require.True(t, ok)
+		assert.Equal(t, factory(), otherFactory())
+	}
+}
+
+func TestConfigOptions(t *testing.T) {
+	defaultIntVal := 50
+	defaultStrVal := "default string"
+	defaultStrSliceVal := []string{"d", "e", "f"}
+	attestorOpts := []Configurer{
+		IntConfigOption("someint", "some int", defaultIntVal, func(a Attestor, v int) (Attestor, error) {
+			da := a.(*dummyAttestor)
+			da.intOpt = v
+			return da, nil
+		}),
+		StringConfigOption("somestring", "some string", defaultStrVal, func(a Attestor, v string) (Attestor, error) {
+			da := a.(*dummyAttestor)
+			da.strOpt = v
+			return da, nil
+		}),
+		StringSliceConfigOption("someslice", "some slice", defaultStrSliceVal, func(a Attestor, v []string) (Attestor, error) {
+			da := a.(*dummyAttestor)
+			da.strSliceOpt = v
+			return da, nil
+		}),
+	}
+
+	RegisterAttestation("optionTest", "optionTest", PreMaterialRunType, func() Attestor { return &dummyAttestor{} }, attestorOpts...)
+	opts := AttestorOptions("optionTest")
+	attestors, err := Attestors([]string{"optionTest"})
+	require.NoError(t, err)
+	require.Len(t, attestors, 1)
+	optAttestor := attestors[0]
+	assert.Equal(t, optAttestor, &dummyAttestor{
+		intOpt:      defaultIntVal,
+		strOpt:      defaultStrVal,
+		strSliceOpt: defaultStrSliceVal,
+	})
+
+	intVal := 100
+	strVal := "test string"
+	strSliceVal := []string{"a", "b", "c"}
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case ConfigOption[int]:
+			_, err = o.Setter()(optAttestor, intVal)
+		case ConfigOption[string]:
+			_, err = o.Setter()(optAttestor, strVal)
+		case ConfigOption[[]string]:
+			_, err = o.Setter()(optAttestor, strSliceVal)
+		default:
+			err = errors.New("unknown config option")
+		}
+
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, optAttestor, &dummyAttestor{
+		intOpt:      intVal,
+		strOpt:      strVal,
+		strSliceOpt: strSliceVal,
+	})
+}
+
+type dummyAttestor struct {
+	name          string
+	predicateType string
+	runType       RunType
+	intOpt        int
+	strOpt        string
+	strSliceOpt   []string
+}
+
+func (a *dummyAttestor) Name() string {
+	return a.name
+}
+
+func (a *dummyAttestor) Type() string {
+	return a.predicateType
+}
+
+func (a *dummyAttestor) RunType() RunType {
+	return a.runType
+}
+
+func (a *dummyAttestor) Attest(*AttestationContext) error {
+	return nil
+}

--- a/attestation/gcp-iit/gcp-iit.go
+++ b/attestation/gcp-iit/gcp-iit.go
@@ -32,7 +32,7 @@ import (
 const (
 	Name    = "gcp-iit"
 	Type    = "https://witness.dev/attestations/gcp-iit/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 
 	jwksUrl = "https://www.googleapis.com/oauth2/v3/certs"
 

--- a/attestation/git/git.go
+++ b/attestation/git/git.go
@@ -26,7 +26,7 @@ import (
 const (
 	Name    = "git"
 	Type    = "https://witness.dev/attestations/git/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/attestation/github/github.go
+++ b/attestation/github/github.go
@@ -31,7 +31,7 @@ import (
 const (
 	Name    = "github"
 	Type    = "https://witness.dev/attestations/github/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 )
 
 const (

--- a/attestation/gitlab/gitlab.go
+++ b/attestation/gitlab/gitlab.go
@@ -26,7 +26,7 @@ import (
 const (
 	Name    = "gitlab"
 	Type    = "https://witness.dev/attestations/gitlab/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/attestation/jwt/jwt.go
+++ b/attestation/jwt/jwt.go
@@ -27,7 +27,7 @@ import (
 const (
 	Name    = "jwt"
 	Type    = "https://witness.dev/attestations/jwt/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/attestation/material/material.go
+++ b/attestation/material/material.go
@@ -16,6 +16,7 @@ package material
 
 import (
 	"encoding/json"
+
 	"github.com/testifysec/go-witness/attestation"
 	"github.com/testifysec/go-witness/attestation/file"
 	"github.com/testifysec/go-witness/cryptoutil"
@@ -24,7 +25,7 @@ import (
 const (
 	Name    = "material"
 	Type    = "https://witness.dev/attestations/material/v0.1"
-	RunType = attestation.Internal
+	RunType = attestation.MaterialRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/attestation/maven/maven.go
+++ b/attestation/maven/maven.go
@@ -27,7 +27,7 @@ import (
 const (
 	Name    = "maven"
 	Type    = "https://witness.dev/attestations/maven/v0.1"
-	RunType = attestation.PreRunType
+	RunType = attestation.PreMaterialRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -34,7 +34,7 @@ import (
 const (
 	Name    = "oci"
 	Type    = "https://witness.dev/attestations/oci/v0.1"
-	RunType = attestation.PostRunType
+	RunType = attestation.PostProductRunType
 
 	mimeTypes = "application/x-tar"
 )

--- a/attestation/oci/oci_test.go
+++ b/attestation/oci/oci_test.go
@@ -38,7 +38,7 @@ func (testProducter) Type() string {
 }
 
 func (testProducter) RunType() attestation.RunType {
-	return attestation.PreRunType
+	return attestation.PreMaterialRunType
 }
 
 func (testProducter) Attest(ctx *attestation.AttestationContext) error {

--- a/attestation/product/product.go
+++ b/attestation/product/product.go
@@ -31,7 +31,7 @@ import (
 const (
 	Name    = "product"
 	Type    = "https://witness.dev/attestations/product/v0.1"
-	RunType = attestation.Internal
+	RunType = attestation.ProductRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor
@@ -48,9 +48,25 @@ func init() {
 	})
 }
 
+type Option func(*Attestor)
+
+func WithIncludeGlob(glob string) Option {
+	return func(a *Attestor) {
+		a.includeGlob = glob
+	}
+}
+
+func WithExcludeGlob(glob string) Option {
+	return func(a *Attestor) {
+		a.excludeGlob = glob
+	}
+}
+
 type Attestor struct {
 	products      map[string]attestation.Product
 	baseArtifacts map[string]cryptoutil.DigestSet
+	includeGlob   string
+	excludeGlob   string
 }
 
 func fromDigestMap(digestMap map[string]cryptoutil.DigestSet) map[string]attestation.Product {

--- a/attestation/sarif/sarif.go
+++ b/attestation/sarif/sarif.go
@@ -30,7 +30,7 @@ import (
 const (
 	Name    = "sarif"
 	Type    = "https://witness.dev/attestations/sarif/v0.1"
-	RunType = attestation.PostRunType
+	RunType = attestation.PostProductRunType
 )
 
 // This is a hacky way to create a compile time error in case the attestor

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -35,10 +35,10 @@ import (
 )
 
 func init() {
-	attestation.RegisterAttestation("dummy-prods", "dummy-prods", attestation.PostRunType, func() attestation.Attestor {
+	attestation.RegisterAttestation("dummy-prods", "dummy-prods", attestation.PostProductRunType, func() attestation.Attestor {
 		return &DummyProducer{}
 	})
-	attestation.RegisterAttestation("dummy-mats", "dummy-mats", attestation.PreRunType, func() attestation.Attestor {
+	attestation.RegisterAttestation("dummy-mats", "dummy-mats", attestation.PreMaterialRunType, func() attestation.Attestor {
 		return &DummyMaterialer{}
 	})
 }
@@ -301,7 +301,7 @@ func (DummyMaterialer) Type() string {
 }
 
 func (DummyMaterialer) RunType() attestation.RunType {
-	return attestation.PreRunType
+	return attestation.PreMaterialRunType
 }
 
 func (DummyMaterialer) Attest(*attestation.AttestationContext) error {
@@ -325,7 +325,7 @@ func (DummyProducer) Type() string {
 }
 
 func (DummyProducer) RunType() attestation.RunType {
-	return attestation.PostRunType
+	return attestation.PostProductRunType
 }
 
 func (DummyProducer) Attest(*attestation.AttestationContext) error {


### PR DESCRIPTION
This adds the ability for attestors to expose available configuration
options including their names, descriptions, and a function that can be
used to set the configuration option on the instantiated attestor.

This will let users of the registry to expose options to the end user,
such as through CLI flags in the case of Witness CLI