### PR TITLE
fix: calculate subjects on demand always

### DIFF
--- a/attestation/aws-iid/aws-iid_test.go
+++ b/attestation/aws-iid/aws-iid_test.go
@@ -108,9 +108,8 @@ func TestAttestor_Attest(t *testing.T) {
 	}
 
 	a := &Attestor{
-		session:  *sess,
-		conf:     conf,
-		subjects: make(map[string]cryptoutil.DigestSet),
+		session: *sess,
+		conf:    conf,
 	}
 
 	ctx, err := attestation.NewContext([]attestation.Attestor{a})
@@ -151,9 +150,8 @@ func TestAttestor_Subjects(t *testing.T) {
 	require.NoError(t, err)
 
 	a := &Attestor{
-		session:  *sess,
-		conf:     conf,
-		subjects: map[string]cryptoutil.DigestSet{},
+		session: *sess,
+		conf:    conf,
 	}
 
 	ctx, err := attestation.NewContext([]attestation.Attestor{a})


### PR DESCRIPTION
We encountered errors with `witness verify` failing unexpectedly despite having the appropriate attestations available. The issue laid with some backrefs not being able to be calculated appropriately, which the policy engine then was unable to build the graph of attestations to satisfy the policy.

The root cause of the issue wound up being that in some attestors subjects were calculated in the `Attest` function and stored for later use in the `Subjects` function. However, this causes issues when we are reading attestations from a source and in a context where `Attest` would have never been run on the attestor being inspected.

The solution I implemented is to calculate subjects (and by extenstion backrefs) on demand from the unexported fields on the attestor structs. This way when we unmarshal them from json we will always be able to re-calculate the subjects.

However, since in many cases we were using the AttestationContext's Hashes functions to decide which hashing functions to use while calculating the subjects, I am currently hard-coding in the hashes instead for the time being.