### PR TITLE
fix(witness): witness should not error on an empty git repo with no commits

### DIFF
--- a/attestation/git/git.go
+++ b/attestation/git/git.go
@@ -17,6 +17,7 @@ package git
 import (
 	"crypto"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -106,6 +107,9 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	head, err := repo.Head()
 	if err != nil {
+		if strings.Contains(err.Error(), "reference not found") {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/testifysec/witness/issues/275

When witness runs on an empty git repo without commits, it shouldn't error with `reference not found` 

## reproduction
1. start a new git repo, do not make any commits
2. run witness on it
3. observe witness fail

## acceptance criteria
- witness doesn't fail on step 3

